### PR TITLE
Add click function to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,4 @@ new Chartist.Bar('.ct-chart', data, {
 | `className` | Add extra classes. | `string` | `''` |
 | `clickable` | Make the legend items clickable; when clicked the corresponding series will disappear. | `bool` | `true` |
 | `legendNames` | Use custom names for the legend. By default the `name` property of the series will be used (for charts labels will be used) | `mixed` | `false` |
+| `chartFnc` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. Must return the chart for changes to take effect. | `mixed` | `false` |

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ new Chartist.Bar('.ct-chart', data, {
 | `className` | Add extra classes. | `string` | `''` |
 | `clickable` | Make the legend items clickable; when clicked the corresponding series will disappear. | `bool` | `true` |
 | `legendNames` | Use custom names for the legend. By default the `name` property of the series will be used (for charts labels will be used) | `mixed` | `false` |
-| `chartFnc` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. Must return the chart for changes to take effect. | `mixed` | `false` |
+| `onClick` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. | `mixed` | `false` |

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -23,7 +23,7 @@
         className: '',
         legendNames: false,
         clickable: true,
-        chartFnc: null
+        onClick: null
     };
 
     Chartist.plugins = Chartist.plugins || {};
@@ -115,8 +115,8 @@
                         seriesCopy.splice(series, 1);
                     });
 
-                    if (options.chartFnc) {
-                        chart = options.chartFnc(chart, e) || chart;
+                    if (options.onClick) {
+                        options.onClick(chart, e);
                     }
 
                     chart.data.series = seriesCopy;

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -22,7 +22,8 @@
     var defaultOptions = {
         className: '',
         legendNames: false,
-        clickable: true
+        clickable: true,
+        chartFnc: null
     };
 
     Chartist.plugins = Chartist.plugins || {};
@@ -113,6 +114,10 @@
                     removedSeries.forEach(function (series) {
                         seriesCopy.splice(series, 1);
                     });
+
+                    if (options.chartFnc) {
+                        chart = options.chartFnc(chart, e) || chart;
+                    }
 
                     chart.data.series = seriesCopy;
 

--- a/test/test.legend.js
+++ b/test/test.legend.js
@@ -167,7 +167,12 @@ describe('Chartist plugin legend', function() {
 
         describe('clickable', function() {
             before(function(done) {
-                chart = generateChart('Line', chartDataLine, { clickable: true });
+                chart = generateChart('Line', chartDataLine, {
+                    clickable: true,
+                    onClick: function(chart,e) {
+                        chart.legendClicked = true;
+                    }
+                });
 
                 chart.on('created', function() {
                     chart.off('created');
@@ -221,6 +226,13 @@ describe('Chartist plugin legend', function() {
                 click(seriesB);
                 var inactiveItem = chart.container.querySelectorAll('ul.ct-legend > li.inactive');
                 expect(inactiveItem.length).to.equal(0);
+            });
+
+            it('should call a function after a click on the legend item', function() {
+                var seriesB = chart.container.querySelector('ul.ct-legend > .ct-series-1');
+
+                click(seriesB);
+                expect(chart.legendClicked).to.equal(true);
             });
         });
     });


### PR DESCRIPTION
This PR implements onClick option. This gives the ability to write a custom function that makes other changes to the chart when a legend is clicked (other than just hiding that legend's series). Provides access to the whole chart, and the click event. 
