### PR TITLE
Added classNames and removeAll options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ new Chartist.Bar('.ct-chart', data, {
 | `clickable` | Make the legend items clickable; when clicked the corresponding series will disappear. | `bool` | `true` |
 | `legendNames` | Use custom names for the legend. By default the `name` property of the series will be used (for charts labels will be used) | `mixed` | `false` |
 | `onClick` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. | `mixed` | `false` |
+| `classNames` | Accepts a array of strings. Those resemble classes added to corresponding legend elements. | `mixed` | `false` |
+| `removeAll` | Allow all series to be removed at once. | `bool` | `false` |

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -115,7 +115,7 @@
                         removedSeries.splice(removedSeriesIndex, 1);
                         li.classList.remove('inactive');
                     } else {
-                        if(!options.removeAll){
+                        if (!options.removeAll){
                              // Remove from series, only if a minimum of one series is still visible.
                           if ( chart.data.series.length > 1)
                           {

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -21,6 +21,8 @@
 
     var defaultOptions = {
         className: '',
+        classNames: false,
+        removeAll: false,
         legendNames: false,
         clickable: true,
         onClick: null
@@ -80,11 +82,19 @@
                 legendNames = chart.data.labels;
             }
             legendNames = options.legendNames || legendNames;
-
+            
+            // Check if given class names are viable to append to legends
+            var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
+            
             // Loop through all legends to set each name in a list item.
             legendNames.forEach(function (legend, i) {
                 var li = document.createElement('li');
                 li.className = 'ct-series-' + i;
+                // Append specific class to a legend element, if viable classes are given
+                if (classNamesViable)
+                {
+                   li.className += ' ' + options.classNames[i];
+                }
                 li.setAttribute('data-legend', i);
                 li.textContent = legend.name || legend;
                 legendElement.appendChild(li);
@@ -106,19 +116,29 @@
                         removedSeries.splice(removedSeriesIndex, 1);
                         li.classList.remove('inactive');
                     } else {
-                        // Remove from series, only if a minimum of one series is still visible.
-                        if (chart.data.series.length > 1) {
-                            removedSeries.push(seriesIndex);
-                            li.classList.add('inactive');
-                        }
-                        // Set all series as active.
-                        else {
-                            removedSeries= [];
-                            var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                            seriesItems.forEach(function(item){
+                        if(!options.removeAll){
+                             // Remove from series, only if a minimum of one series is still visible.
+                          if (chart.data.series.length > 1)
+                          {
+                             removedSeries.push(seriesIndex);
+                             li.classList.add('inactive');
+                          }
+                             // Set all series as active.
+                          else
+                          {
+                             removedSeries = [];
+                             var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
+                             seriesItems.forEach(function (item)
+                             {
                                 item.classList.remove('inactive');
-                            });
-                        }
+                             });
+                          }
+                       }
+                       else{
+                          // Remove series unaffected if it is the last or not
+                          removedSeries.push(seriesIndex);
+                          li.classList.add('inactive');
+                       }
                     }
 
                     // Reset the series to original and remove each series that

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -91,8 +91,7 @@
                 var li = document.createElement('li');
                 li.className = 'ct-series-' + i;
                 // Append specific class to a legend element, if viable classes are given
-                if (classNamesViable)
-                {
+                if (classNamesViable) {
                    li.className += ' ' + options.classNames[i];
                 }
                 li.setAttribute('data-legend', i);
@@ -118,23 +117,21 @@
                     } else {
                         if(!options.removeAll){
                              // Remove from series, only if a minimum of one series is still visible.
-                          if (chart.data.series.length > 1)
+                          if ( chart.data.series.length > 1)
                           {
                              removedSeries.push(seriesIndex);
                              li.classList.add('inactive');
                           }
                              // Set all series as active.
-                          else
-                          {
+                          else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             seriesItems.forEach(function (item)
-                             {
+                             seriesItems.forEach(function (item) {
                                 item.classList.remove('inactive');
                              });
                           }
                        }
-                       else{
+                       else {
                           // Remove series unaffected if it is the last or not
                           removedSeries.push(seriesIndex);
                           li.classList.add('inactive');

--- a/test/test.legend.js
+++ b/test/test.legend.js
@@ -205,6 +205,38 @@ describe('Chartist plugin legend', function() {
                 done();
             });
         });
+        
+        it('should allow multiple custom class names', function (done) {
+           var classNames = ['multiclass-0', 'multiclass-1', 'multiclass-hidden'];
+           chart = generateChart('Line', chartDataLine, { classNames: classNames });
+
+           chart.on('created', function () {
+              var legend = chart.container.querySelector('ul.ct-legend');
+
+              expect(chart.data.series.length).to.equal(3);
+              expect(legend.children[0].classList.contains(classNames[0])).to.be.true;
+              expect(legend.children[1].classList.contains(classNames[1])).to.be.true;
+              expect(legend.children[2].classList.contains(classNames[2])).to.be.true;
+              destroyChart();
+              done();
+           });
+        });
+
+        it('should allow to remove all series at once', function () {
+           chart = generateChart('Line', chart2DataLine, { removeAll: true });
+
+           chart.on('created', function () {
+              var seriesA = chart.container.querySelector('ul.ct-legend > .ct-series-0');
+
+              expect(chart.data.series.length).to.equal(1);
+              click(seriesA);
+              expect(chart.data.series.length).to.equal(0);
+              click(seriesA);
+              expect(chart.data.series.length).to.equal(1);
+              destroyChart();
+              done();
+           });
+        })
 
         describe('clickable', function() {
             before(function(done) {


### PR DESCRIPTION
I've added two additional optional options and the corresponding logic for this plugin:
# classNames

`classNames` is a passable optional option, it's type is a `array of strings`.

It sepcifies classes for each legend `li` element.
If a valid array is passed, which is as long as the number of series (or, if passed as long as `legendNames`), those classes will be appended dynamically to their corresponding elements.
This allows generating classes for specific elements and to style them via CSS.

A specific example is stacking charts, and hiding overlapping legends for positioning purposes.
# removeAll

`removeAll`  is a passable optional option, it's type is `boolean`.

It can be set to allow the user to remove every single entry of data in a chart.
This is not enabled by default to retain the developer's default, but enables a more flexible usage of the toggle funcionality depending on personal preference.
