### PR TITLE
Fix #22 and add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ new Chartist.Bar('.ct-chart', data, {
 
 | __Option__ | __Description__ | __Type__ | __Default__ |
 | ---        | ---             | ---      | ---         |
-| `className` | Add extra classes. | `string` | `''` |
-| `clickable` | Make the legend items clickable; when clicked the corresponding series will disappear. | `bool` | `true` |
-| `legendNames` | Use custom names for the legend. By default the `name` property of the series will be used (for charts labels will be used) | `mixed` | `false` |
+| `className` | Adds a class to the `ul` element. | `string` | `''` |
+| `clickable` | Sets the legends clickable state; when clicked the corresponding series will disappear. | `bool` | `true` |
+| `legendNames` | Sets custom legend names. By default the `name` property of the series will be used if none are given. | `mixed` | `false` |
 | `onClick` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. | `mixed` | `false` |
-| `classNames` | Accepts a array of strings. Those resemble classes added to corresponding legend elements. | `mixed` | `false` |
+| `classNames` | Accepts a array of strings as long as the chart's series, those will be added as classes to the `li` elements. | `mixed` | `false` |
 | `removeAll` | Allow all series to be removed at once. | `bool` | `false` |
+| `position` | Sets the position of the legend element. `top`and `bottom`are currently accepted. | `'top'|'bottom'` | `'top'` |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ new Chartist.Bar('.ct-chart', data, {
 | __Option__ | __Description__ | __Type__ | __Default__ |
 | ---        | ---             | ---      | ---         |
 | `className` | Adds a class to the `ul` element. | `string` | `''` |
-| `clickable` | Sets the legends clickable state; when clicked the corresponding series will disappear. | `bool` | `true` |
+| `clickable` | Sets the legends clickable state; setting this value to `false` disables toggling graphs on legend click. | `bool` | `true` |
 | `legendNames` | Sets custom legend names. By default the `name` property of the series will be used if none are given. | `mixed` | `false` |
 | `onClick` | Accepts a function that gets invoked if `clickable` is true. The function has the `chart`, and the click event (`e`), as arguments. | `mixed` | `false` |
 | `classNames` | Accepts a array of strings as long as the chart's series, those will be added as classes to the `li` elements. | `mixed` | `false` |

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -82,10 +82,10 @@
                 legendNames = chart.data.labels;
             }
             legendNames = options.legendNames || legendNames;
-            
+
             // Check if given class names are viable to append to legends
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
-            
+
             // Loop through all legends to set each name in a list item.
             legendNames.forEach(function (legend, i) {
                 var li = document.createElement('li');

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -93,7 +93,7 @@
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
 
             // Loop through all legends to set each name in a list item.
-            for (var legendNamesIndex = 0; legendNamesIndex < legendNames.length; legendNamesIndex++) {
+            for (var legendNamesIndex = 0, length = legendNames.length; legendNamesIndex < length; legendNamesIndex++) {
                var legend = legendNames[legendNamesIndex];
                var li = document.createElement('li');
                li.className = 'ct-series-' + legendNamesIndex;
@@ -134,7 +134,7 @@
                           else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             for (var seriesItemsIndex = 0; seriesItemsIndex < seriesItems.length; seriesItemsIndex++)
+                             for (var seriesItemsIndex = 0, length = seriesItems.length; seriesItemsIndex < length; seriesItemsIndex++)
                              {
                                 seriesItems[seriesItemsIndex].classList.remove('inactive');
                              }
@@ -157,7 +157,7 @@
                     // Reverse sort the removedSeries to prevent removing the wrong index.
                     removedSeries.sort(compareNumbers).reverse();
 
-                    for (var removedSeriesIndex = 0; removedSeriesIndex < removedSeries.length; removedSeriesIndex++)
+                    for (var removedSeriesIndex = 0, length = removedSeries.length; removedSeriesIndex < removedSeries.length; removedSeriesIndex++)
                     {
                        var series = removedSeries[removedSeriesIndex];
                        seriesCopy.splice(series, 1);

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -38,8 +38,10 @@
         }
 
         // Catch invalid options
-        if (options.position && options.position !== 'top' || options.position !== 'bottom') {
-           throw Error('The position you entered is not a valid position')
+        if (options && options.position) {
+           if (!(options.position === 'top' || options.position === 'bottom')) {
+              throw Error('The position you entered is not a valid position');
+           }
         }
 
         options = Chartist.extend({}, defaultOptions, options);
@@ -95,7 +97,7 @@
             // Loop through all legends to set each name in a list item.
             legendNames.forEach(function (legend, i) {
                var li = document.createElement('li');
-               li.className = 'ct-series-' + i;s
+               li.className = 'ct-series-' + i;
                // Append specific class to a legend element, if viable classes are given
                if (classNamesViable) {
                   li.className += ' ' + options.classNames[i];

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -19,13 +19,19 @@
      */
     'use strict';
 
+    var positionEnum = {
+       top: 0,
+       bottom: 1
+    };
+
     var defaultOptions = {
         className: '',
         classNames: false,
         removeAll: false,
         legendNames: false,
         clickable: true,
-        onClick: null
+        onClick: null,
+        position: positionEnum.top
     };
 
     Chartist.plugins = Chartist.plugins || {};
@@ -87,17 +93,19 @@
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
 
             // Loop through all legends to set each name in a list item.
-            legendNames.forEach(function (legend, i) {
-                var li = document.createElement('li');
-                li.className = 'ct-series-' + i;
-                // Append specific class to a legend element, if viable classes are given
-                if (classNamesViable) {
-                   li.className += ' ' + options.classNames[i];
-                }
-                li.setAttribute('data-legend', i);
-                li.textContent = legend.name || legend;
-                legendElement.appendChild(li);
-            });
+            for (var legendNamesIndex = 0; legendNamesIndex < legendNames.length; legendNamesIndex++) {
+               var legend = legendNames[legendNamesIndex];
+               var li = document.createElement('li');
+               li.className = 'ct-series-' + legendNamesIndex;
+               // Append specific class to a legend element, if viable classes are given
+               if (classNamesViable)
+               {
+                  li.className += ' ' + options.classNames[legendNamesIndex];
+               }
+               li.setAttribute('data-legend', legendNamesIndex);
+               li.textContent = legend.name || legend;
+               legendElement.appendChild(li);
+            }
             chart.container.appendChild(legendElement);
 
             if (options.clickable) {
@@ -126,9 +134,10 @@
                           else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             seriesItems.forEach(function (item) {
-                                item.classList.remove('inactive');
-                             });
+                             for (var seriesItemsIndex = 0; seriesItemsIndex < seriesItems.length; seriesItemsIndex++)
+                             {
+                                seriesItems[seriesItemsIndex].classList.remove('inactive');
+                             }
                           }
                        }
                        else {
@@ -148,12 +157,15 @@
                     // Reverse sort the removedSeries to prevent removing the wrong index.
                     removedSeries.sort(compareNumbers).reverse();
 
-                    removedSeries.forEach(function (series) {
-                        seriesCopy.splice(series, 1);
-                        if (useLabels) {
-                            labelsCopy.splice(series, 1);
-                        }
-                    });
+                    for (var removedSeriesIndex = 0; removedSeriesIndex < removedSeries.length; removedSeriesIndex++)
+                    {
+                       var series = removedSeries[removedSeriesIndex];
+                       seriesCopy.splice(series, 1);
+                       if (useLabels)
+                       {
+                          labelsCopy.splice(series, 1);
+                       }
+                    }
 
                     if (options.onClick) {
                         options.onClick(chart, e);

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -95,7 +95,7 @@
             // Loop through all legends to set each name in a list item.
             legendNames.forEach(function (legend, i) {
                var li = document.createElement('li');
-               li.className = 'ct-series-' + i;
+               li.className = 'ct-series-' + i;s
                // Append specific class to a legend element, if viable classes are given
                if (classNamesViable) {
                   li.className += ' ' + options.classNames[i];
@@ -143,8 +143,7 @@
                           else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             seriesItems.forEach(function (item)
-                             {
+                             seriesItems.forEach(function (item) {
                                 item.classList.remove('inactive');
                              });
                           }

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -49,8 +49,7 @@
            }
            options.position = positionEnum[options.position];
            // Catch invalid parses
-           if (options.position === undefined)
-           {
+           if (options.position === undefined) {
               throw Error('The position you entered is not a valid position')
            }
         }
@@ -102,8 +101,6 @@
             }
             legendNames = options.legendNames || legendNames;
 
-            console.log(legendNames);
-
             // Check if given class names are viable to append to legends
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
 
@@ -113,22 +110,19 @@
                var li = document.createElement('li');
                li.className = 'ct-series-' + legendNamesIndex;
                // Append specific class to a legend element, if viable classes are given
-               if (classNamesViable)
-               {
+               if (classNamesViable) {
                   li.className += ' ' + options.classNames[legendNamesIndex];
                }
                li.setAttribute('data-legend', legendNamesIndex);
                li.textContent = legend.name || legend;
                legendElement.appendChild(li);
             }
-            console.log(legendElement);
 
             chart.on('created', function (data) {
-               console.log(legendElement);
                // Append the legend element to the DOM
                switch (options.position) {
                   case positionEnum.top:
-                     chart.container.appendChild(legendElement);
+                     chart.container.insertBefore(legendElement, chart.container.childNodes[0]);
                      break;
 
                   case positionEnum.bottom:
@@ -152,10 +146,9 @@
                         removedSeries.splice(removedSeriesIndex, 1);
                         li.classList.remove('inactive');
                     } else {
-                        if (!options.removeAll){
+                        if (!options.removeAll) {
                              // Remove from series, only if a minimum of one series is still visible.
-                          if ( chart.data.series.length > 1)
-                          {
+                          if ( chart.data.series.length > 1) {
                              removedSeries.push(seriesIndex);
                              li.classList.add('inactive');
                           }
@@ -163,8 +156,7 @@
                           else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             for (var seriesItemsIndex = 0, length = seriesItems.length; seriesItemsIndex < length; seriesItemsIndex++)
-                             {
+                             for (var seriesItemsIndex = 0, length = seriesItems.length; seriesItemsIndex < length; seriesItemsIndex++) {
                                 seriesItems[seriesItemsIndex].classList.remove('inactive');
                              }
                           }
@@ -186,12 +178,10 @@
                     // Reverse sort the removedSeries to prevent removing the wrong index.
                     removedSeries.sort(compareNumbers).reverse();
 
-                    for (var removedSeriesIndex = 0, length = removedSeries.length; removedSeriesIndex < removedSeries.length; removedSeriesIndex++)
-                    {
+                    for (var removedSeriesIndex = 0, length = removedSeries.length; removedSeriesIndex < removedSeries.length; removedSeriesIndex++) {
                        var series = removedSeries[removedSeriesIndex];
                        seriesCopy.splice(series, 1);
-                       if (useLabels)
-                       {
+                       if (useLabels) {
                           labelsCopy.splice(series, 1);
                        }
                     }

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -42,6 +42,19 @@
             return a - b;
         }
 
+        // Parse input position string to enum
+        if (options && options.position) {
+           if (typeof options.position === 'string') {
+              options.position = options.position.toLowerCase();
+           }
+           options.position = positionEnum[options.position];
+           // Catch invalid parses
+           if (options.position === undefined)
+           {
+              throw Error('The position you entered is not a valid position')
+           }
+        }
+
         options = Chartist.extend({}, defaultOptions, options);
 
         return function legend(chart) {
@@ -89,6 +102,8 @@
             }
             legendNames = options.legendNames || legendNames;
 
+            console.log(legendNames);
+
             // Check if given class names are viable to append to legends
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
 
@@ -106,7 +121,21 @@
                li.textContent = legend.name || legend;
                legendElement.appendChild(li);
             }
-            chart.container.appendChild(legendElement);
+            console.log(legendElement);
+
+            chart.on('created', function (data) {
+               console.log(legendElement);
+               // Append the legend element to the DOM
+               switch (options.position) {
+                  case positionEnum.top:
+                     chart.container.appendChild(legendElement);
+                     break;
+
+                  case positionEnum.bottom:
+                     chart.container.insertBefore(legendElement, null);
+                     break;
+               }
+            });
 
             if (options.clickable) {
                 legendElement.addEventListener('click', function (e) {

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -94,14 +94,13 @@
 
             // Loop through all legends to set each name in a list item.
             legendNames.forEach(function (legend, i) {
-               var legend = legendNames[legendNamesIndex];
                var li = document.createElement('li');
-               li.className = 'ct-series-' + legendNamesIndex;
+               li.className = 'ct-series-' + i;
                // Append specific class to a legend element, if viable classes are given
                if (classNamesViable) {
-                  li.className += ' ' + options.classNames[legendNamesIndex];
+                  li.className += ' ' + options.classNames[i];
                }
-               li.setAttribute('data-legend', legendNamesIndex);
+               li.setAttribute('data-legend', i);
                li.textContent = legend.name || legend;
                legendElement.appendChild(li);
             });
@@ -109,11 +108,11 @@
             chart.on('created', function (data) {
                // Append the legend element to the DOM
                switch (options.position) {
-                  case '.top':
+                  case 'top':
                      chart.container.insertBefore(legendElement, chart.container.childNodes[0]);
                      break;
 
-                  case '.bottom':
+                  case 'bottom':
                      chart.container.insertBefore(legendElement, null);
                      break;
                }
@@ -167,13 +166,12 @@
                     // Reverse sort the removedSeries to prevent removing the wrong index.
                     removedSeries.sort(compareNumbers).reverse();
 
-                    for (var removedSeriesIndex = 0, length = removedSeries.length; removedSeriesIndex < removedSeries.length; removedSeriesIndex++) {
-                       var series = removedSeries[removedSeriesIndex];
-                       seriesCopy.splice(series, 1);
-                       if (useLabels) {
-                          labelsCopy.splice(series, 1);
-                       }
-                    }
+                    removedSeries.forEach(function (series) {
+                        seriesCopy.splice(series, 1);
+                        if (useLabels) {
+                            labelsCopy.splice(series, 1);
+                        }
+                    });
 
                     if (options.onClick) {
                         options.onClick(chart, e);

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -19,11 +19,6 @@
      */
     'use strict';
 
-    var positionEnum = {
-       top: 0,
-       bottom: 1
-    };
-
     var defaultOptions = {
         className: '',
         classNames: false,
@@ -31,7 +26,7 @@
         legendNames: false,
         clickable: true,
         onClick: null,
-        position: positionEnum.top
+        position: 'top'
     };
 
     Chartist.plugins = Chartist.plugins || {};
@@ -42,16 +37,9 @@
             return a - b;
         }
 
-        // Parse input position string to enum
-        if (options && options.position) {
-           if (typeof options.position === 'string') {
-              options.position = options.position.toLowerCase();
-           }
-           options.position = positionEnum[options.position];
-           // Catch invalid parses
-           if (options.position === undefined) {
-              throw Error('The position you entered is not a valid position')
-           }
+        // Catch invalid options
+        if (options.position && options.position !== 'top' || options.position !== 'bottom') {
+           throw Error('The position you entered is not a valid position')
         }
 
         options = Chartist.extend({}, defaultOptions, options);
@@ -121,11 +109,11 @@
             chart.on('created', function (data) {
                // Append the legend element to the DOM
                switch (options.position) {
-                  case positionEnum.top:
+                  case '.top':
                      chart.container.insertBefore(legendElement, chart.container.childNodes[0]);
                      break;
 
-                  case positionEnum.bottom:
+                  case '.bottom':
                      chart.container.insertBefore(legendElement, null);
                      break;
                }

--- a/chartist-plugin-legend.js
+++ b/chartist-plugin-legend.js
@@ -93,7 +93,7 @@
             var classNamesViable = (Array.isArray(options.classNames) && (options.classNames.length === legendNames.length));
 
             // Loop through all legends to set each name in a list item.
-            for (var legendNamesIndex = 0, length = legendNames.length; legendNamesIndex < length; legendNamesIndex++) {
+            legendNames.forEach(function (legend, i) {
                var legend = legendNames[legendNamesIndex];
                var li = document.createElement('li');
                li.className = 'ct-series-' + legendNamesIndex;
@@ -104,7 +104,7 @@
                li.setAttribute('data-legend', legendNamesIndex);
                li.textContent = legend.name || legend;
                legendElement.appendChild(li);
-            }
+            });
 
             chart.on('created', function (data) {
                // Append the legend element to the DOM
@@ -144,9 +144,10 @@
                           else {
                              removedSeries = [];
                              var seriesItems = Array.prototype.slice.call(legendElement.childNodes);
-                             for (var seriesItemsIndex = 0, length = seriesItems.length; seriesItemsIndex < length; seriesItemsIndex++) {
-                                seriesItems[seriesItemsIndex].classList.remove('inactive');
-                             }
+                             seriesItems.forEach(function (item)
+                             {
+                                item.classList.remove('inactive');
+                             });
                           }
                        }
                        else {

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
    ]
 });</code></pre>
       <h3>Chart with <i>clickable</i>:</h3>
-      <span>Sets the legends clickable state; when clicked the corresponding series will disappear.</span>
+      <span>Sets the legends clickable state; setting this value to <code>ul</code> disables toggling graphs on legend click.</span>
       <div class="ct-chart-line-clickable"></div>
       <button class="button-showcode">Show Code</button>
 <pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-clickable', {

--- a/index.html
+++ b/index.html
@@ -1,120 +1,649 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 
 <head>
     <meta charset="utf-8">
 
-    <title>Legend examples</title>
+    <title>chartist-plugin-legend examples</title>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/4.2.0/normalize.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chartist/0.9.8/chartist.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/default.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Oxygen:400,300,700%7CSource+Code+Pro:400,700" media="all">
 
     <style>
-    .ct-chart {
-        position: relative;
-    }
-    .ct-legend {
-        position: relative;
-        z-index: 10;
-        list-style: none;
-    }
-    .ct-legend li {
-        position: relative;
-        padding-left: 23px;
-        margin-bottom: 3px;
-        cursor: pointer;
-    }
-    .ct-legend li:before {
-        width: 12px;
-        height: 12px;
-        position: absolute;
-        left: 0;
-        content: '';
-        border: 3px solid transparent;
-        border-radius: 2px;
-    }
-    .ct-legend li.inactive:before {
-        background: transparent;
-    }
-    .ct-legend.ct-legend-inside {
-        position: absolute;
-        top: 0;
-        right: 0;
-    }
-    .ct-legend .ct-series-0:before {
-        background-color: #d70206;
-        border-color: #d70206;
-    }
-    .ct-legend .ct-series-1:before {
-        background-color: #f05b4f;
-        border-color: #f05b4f;
-    }
-    .ct-legend .ct-series-2:before {
-        background-color: #f4c63d;
-        border-color: #f4c63d;
-    }
-    .ct-legend .ct-series-3:before {
-        background-color: #d17905;
-        border-color: #d17905;
-    }
-    .ct-legend .ct-series-4:before {
-        background-color: #453d3f;
-        border-color: #453d3f;
-    }
+       .ct-chart {
+           position: relative;
+       }
+       .ct-legend {
+           position: relative;
+           z-index: 10;
+           list-style: none;
+           text-align: center;
+       }
+       .ct-legend li {
+           position: relative;
+           padding-left: 23px;
+           margin-right: 10px;
+           margin-bottom: 3px;
+           cursor: pointer;
+           display: inline-block;
+       }
+       .ct-legend li:before {
+           width: 12px;
+           height: 12px;
+           position: absolute;
+           left: 0;
+           content: '';
+           border: 3px solid transparent;
+           border-radius: 2px;
+       }
+       .ct-legend li.inactive:before {
+           background: transparent;
+       }
+       .ct-legend.ct-legend-inside {
+           position: absolute;
+           top: 0;
+           right: 0;
+       }
+       .ct-legend.ct-legend-inside li{
+           display: block;
+           margin: 0;
+       }
+       .ct-legend .ct-series-0:before {
+           background-color: #d70206;
+           border-color: #d70206;
+       }
+       .ct-legend .ct-series-1:before {
+           background-color: #f05b4f;
+           border-color: #f05b4f;
+       }
+       .ct-legend .ct-series-2:before {
+           background-color: #f4c63d;
+           border-color: #f4c63d;
+       }
+       .ct-legend .ct-series-3:before {
+           background-color: #d17905;
+           border-color: #d17905;
+       }
+       .ct-legend .ct-series-4:before {
+           background-color: #453d3f;
+           border-color: #453d3f;
+       }
+
+       .crazyPink li.ct-series-0:before {
+          background-color: #C2185B;
+          border-color: #C2185B;
+       }
+
+       .crazyPink li.ct-series-1:before {
+          background-color: #E91E63;
+          border-color: #E91E63;
+       }
+
+       .crazyPink li.ct-series-2:before {
+          background-color: #F06292;
+          border-color: #F06292;
+       }
+       .crazyPink li.inactive:before {
+          background-color: transparent;
+       }
+
+       .crazyPink ~ svg .ct-series-a .ct-line, .crazyPink ~ svg .ct-series-a .ct-point {
+          stroke: #C2185B;
+       }
+
+       .crazyPink ~ svg .ct-series-b .ct-line, .crazyPink ~ svg .ct-series-b .ct-point {
+          stroke: #E91E63;
+       }
+
+       .crazyPink ~ svg .ct-series-c .ct-line, .crazyPink ~ svg .ct-series-c .ct-point {
+          stroke: #F06292;
+       }
+       /* Page styling */
+       h1, h2, h3{
+          color: #5b4421;
+          text-transform: uppercase;
+       }
+
+       h1, h2{
+          text-align: center;
+       }
+
+       h3 > * {
+          text-transform: none;
+       }
+
+       .codeblock-hidden{
+          display: none;
+       }
+
+      .javascript.hljs {
+             background-color: #453D3F;
+             padding: 1.3333333333rem;
+             color: #f7f2ea;
+             font-family: "Source Code Pro","Courier New",monospace!important;
+             line-height: 1.4;
+             word-wrap: break-word;
+             height: auto;
+             margin-bottom: 1.3333333333rem
+       }
+
+       .ct-hidden {
+          opacity: 0;
+       }
+
+       .ct-dimmed {
+          opacity: 0.5;
+       }
+
+       .javascript.hljs span::selection, .javascript.hljs::selection {
+         background: #2a2526!important
+       }
+
+       .javascript.hljs .hljs-comment {
+             color: #7b6d70
+       }
+
+       .javascript.hljs .hljs-atom,.javascript.hljs .hljs-number {
+             color: #F4C63D
+       }
+
+       .cm-s-3024-day .hljs-attribute,.javascript.hljs .hljs-property {
+             color: #f7f2ea
+       }
+
+       .javascript.hljs .hljs-keyword {
+             color: #F05B4F;
+             font-weight: 700
+       }
+
+       .javascript.hljs .hljs-string {
+             color: #F4C63D
+       }
+
+       .javascript.hljs .hljs-variable {
+             color: #f7f2ea
+       }
+
+       .javascript.hljs .hljs-def,.javascript.hljs .hljs-variable-2 {
+             color: #f8b3ad
+       }
+
+       .javascript.hljs .hljs-bracket {
+             color: #3a3432
+       }
+
+       .javascript.hljs .hljs-tag {
+             color: #F05B4F;
+             font-weight: 700
+       }
+
+       .javascript.hljs .hljs-link {
+             color: #F4C63D
+       }
+
+       .javascript.hljs .hljs-error{
+             background-color: #F05B4F;
+             color: #453D3F
+       }
+
+       .javascript.hljs .hljs-literal{
+             color: #F05B4F;
+       }
+
+       .javascript.hljs .CodeMirror-activeline-background {
+             background: #e8f2ff!important
+       }
+
+       .javascript.hljs .CodeMirror-matchingbracket {
+             text-decoration: underline;
+             color: #fff!important
+       }
+       .button, button {
+          border-radius: 0;
+          border-style: solid;
+          border-width: 0;
+          cursor: pointer;
+          font-weight: 400;
+          line-height: normal;
+          margin: 5px auto;
+          text-align: center;
+          display: block;
+          padding: 1rem 2rem 1.0625rem;
+          font-size: 1rem;
+          background-color: #F4C63D;
+          border-color: #e7b00d;
+          color: #453D3F;
+       }
+       body {
+          background: #EADBC4;
+          line-height: 1.54;
+          background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAYAAAAeP4ixAAAIoElEQVRoQ23a7bETOxCE4eNfJxEIBnKBYCAXCAZy4bpVPK4X1XWVWe+uPkYz3T0jHR6/fv16f3t+Pn369Pb8vZ9vP3/+fPv9+/d59uHDh/P748ePb1++fDnXvd937ff+69ev53nH2O+12btd9/n27dtps/vv37+fvnu233tm/I1rfvbs3Z65bly/N8ZjC2HMefB4vAxk8CbfZJuAwfrsGcMsxDg/fvw47TepBTByRqzdjNuzz58/n4WtnUXPlrXbs73veMbZs30ez0bvG3CT7crzovLnz58z2d7tu88G3eC7t5Ddr90+G0t0d7/nM3JjGkNERYyztOOU2dMI7b6fvdv38TT0QGur3+oYaSId5xlGisaitAnvcFuUPmu3T2G4BYn4novC5tsXDG+IQcUcrN3GeTwHeN+Em4yHYRHG17ket0jexZE9X7t994yBu78NFAk8mQPBjYPKm7U3pghxxPo9nv+8M3wT4gjI7B0D/4lpyAv/oLMFMmyTg5boFnbmwTORGjpEcmPsgw9gL2oHWuMIQwqRhQ4BZ8gGQdrd40GVjiDMy3OICNebFIxzyh/PtuCNYZFbhCjjnHkh4HCkqlMJrXQyblcTEQmRgmeT3oJAoTih44NNpbryjV91iggf257GHI7MgyIjZFUxYlAjQXHR2/sSsCrIo/qScE7j1UapqkWmZ/CiDna4chby/OdwZEYg/CYme5VMyWsdB7v1oWR4Jm8Uv+AgQiKC1FUs0V1b0SfrFNJiKveH7F2xRcic87REJZ/I9p2oWf7/8k2rAbmKE6gaR20sBN+7fcguJQSxjXsissxOTkuoarQwU6BFgnKQyIa8ULVoWVniK78Y3nnArVCupJNzue9ExOplVZ7nsV1n3OBUqPGOdq23kHbv9htUW7uBj/mbFwgQ+LrHo5Yzs+uoloRmUlhcAx8lCkFoUcloOWeTi17H4j2QxA2OQGbvIYUjtJfAFZmb65+EOMNhcZ14T701o0go73Vy+aayKZdsvMFvk8tHKmAwLgdV2e0v4kgut23sf1RrC6E2SHQaRZphl1csGHSqWnhQwhaeFQBtKaIM3zE4YHODmMT7eK7qFI3C12wMPgYFge4NZngTHQgyUhTnPbBE4NZb5pf4umUAKbmpOWvtFtnDkXLhzsbIfReGSoQZTqJvkUDUliHkXQQtrsbuHdg06a2NfQnnK4tOrVWF2QC8A88w7NrSYgtp2QKGhZ5MTJblBeOo61TZ99ZBBMBc1HHlFI3L7LRdSU2pLAhMNgAZtmDhVkjWaIaKMrJ6brHNXxxDGETBItlSDr9Uq+UIzLXmbw2FuMp0RnRvwgGEQZUAYozs9rkQolhbxBzTYrSqyZazkEFLYiKRMwQ516jlOYnmZfmCAMwg4kBeK7Ptt/koEA6KtFquiXDt5SV83HwnITazrxFviIK6SEli+7q2xW5LFp7CsW7OWhmAi1OUe5EkVuLT3qKb804Zvxc9ZKDXrTqVIyX82nUnx0hXOaEFn7wAZjjWOqpOKxxbEkGJyv11HGS/AV4mF/ritAluz220SCjxUAyq4dRUpBNhuxNVTYCqqDRaxuWEzX8iAqsiUQIjLo/JG/q09mIYLzF8V1iWW8CpUZQGNiaSN7FyqoW3TDoRoctICf+wWfUhBEgucd11U0sLcGzyAzse7x6n0muvtHbykLyF+IfsiwjsyZpVIrtGE5LJlhAWKtsPpqQTVBkqAgxshIzNgfKO6NuDiBiInkT5/L7fW1aTKiBBY/c9uqwE2ra2r0iTcIpnHA7ALcc/EvKdweWqXbvxO5l98gsWFML+Gx9kdFHZRJXAPRchk1EeC5vRcsz6tswh08hrHm1EWj8VAViv/atoRNSqBDViNA92J2hRnRwpi29Khxvr5/QFlERm/XryiVu2CERB/9eeXdJTqth/bwCliER5e0+YqRu+Vfn2W1L0nndxiXNEtAJxn9TL9o3y2Y8gt9KCcZukpIZZHtt7OaLPkFDoQZWXGd1Dc326zUVyTlBQgi2oTlxep/EGR7h16p7jKMPfo6EmPpGS5e1tJDBwxD81FGVTCuGH7XLrNGe+PeieDVRs719bXcZV0lo6W6g8ghPdq/AmbvSKoBwE5yBZjh4Vus6OQQ5MRUMRe+SX56vxapkS7az87/7dORWptCBjSaoMx0Oe7zmA7W35YXzP1H0SI7tUD6/ql4fkDKGDY1zpbm5tW4brC264xnsihFu83vIH9PAWB1Xmu7eIRvWUKLzqRbM3Y9RhJaUkaDHe2fysr8WprXrgxsv1esui5hoRsmjbYVA/EYE7k/J0t68iZPAWdrhxY5taySHln3H0ZSCoNIfham0gvbj6Ovut7OFKC7kNUhlcG0rVUxT7/h4lKQLLN1zq9mDGO6UUJerWqEvCuHXK+EVEIuQl4YL1e0MjKZrMoZtaCgxnLPjVw7J7YSZrF+b/V1ByAHGR605EeAL5bGqEuaRtXbX3zQPai+7GKTElRIT198pGF7/AaG3x695p1jmnjFdOrPN+C1nrpzvrW9Da87rMv3tbZ/mh+t+q2WJ4li2M7O7RH6OoXkXlZPZm525t10GZAXY9LVHSW4ykirgMJiI9hAARzrsr6FvlCA9FxUV2HY5Udr2QwBRoDhkaCVzAMd4sR0S1BO2f7Rycg2PnNRe1U6IQnkbmpVogoMYxSHnSMy2evMsRELEYGJ8nlSPgu/suVNW9vlLArreorP+QYWEb49RaQm/Q+xyqRz5C2xKCXKvHdu1envrU+/DNaOPeXOy2d79V2UoVtHjVWpQDYVtmkFHhv//ypI8oURzR4XmVdc+HVcXgyRmqZl4v37xTYW/cc2SqGGw9VW44USSfd7kCw/YL3svoFtKECrKMAmVOKxSJThMvfhjnddLYfbH0j6DdWzRjN9uDAEwr9rqpaja3xzCHxZ5t69//fICTajLnwlTSHBvjP9uuEN4BiDLbAAAAAElFTkSuQmCC);
+          background-position: 50% 50%;
+          background-repeat: repeat repeat;
+       }
     </style>
 </head>
 <body>
-    <div style="max-width: 700px; margin: 0 auto;">
-        <div class="ct-chart ct-chart-line"></div>
-        <div class="ct-chart ct-chart-pie"></div>
-        <div class="ct-chart ct-chart-bar"></div>
-    </div>
+   <div style="max-width: 700px; margin: 0 auto 40px auto;">
+      <h1>chartist-plugin-legend examples</h1>
+      <h2>basic examples</h2>
+      <h3>Line Chart:</h3>
+      <div class="ct-chart ct-chart-line"></div>
+      <button class="button-showcode">Show Code</button>
+      <pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend()
+   ]
+});</code></pre>
+      <h3>Pie Chart:</h3>
+      <div class="ct-chart ct-chart-pie"></div>
+      <button class="button-showcode">Show Code</button>
+      <pre class="codeblock-hidden"><code class="javascript">new Chartist.Pie('.ct-chart-pie', {
+    labels: ['Piece A', 'Piece B', 'Piece C', 'Piece D'],
+    series: [20, 10, 30, 40]
+}, {
+    showLabel: false,
+    plugins: [
+        Chartist.plugins.legend()
+    ]
+});</code></pre>
+      <h3>Bar Chart:</h3>
+      <div class="ct-chart ct-chart-bar"></div>
+      <button class="button-showcode">Show Code</button>
+      <pre class="codeblock-hidden"><code class="javascript">new Chartist.Bar('.ct-chart-bar', {
+   labels: ['First quarter of the year', 'Second quarter of the year', 'Third quarter of the year', 'Fourth quarter of the year'],
+   series: [
+       { "name": "Money A", "data": [60000, 40000, 80000, 70000] },
+       { "name": "Money B", "data": [40000, 30000, 70000, 65000] },
+       { "name": "Money C", "data": [8000, 3000, 10000, 6000] }
+   ]
+}, {
+   plugins: [
+       Chartist.plugins.legend()
+   ]
+});</code></pre>
+      <h2>examples with options</h2>
+      <h3>Chart with <i>className</i>:</h3>
+      <span>Adds a class to the <code>ul</code> element.</span>
+      <div class="ct-chart-line-classname"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-classname', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          className: 'crazyPink'
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>clickable</i>:</h3>
+      <span>Sets the legends clickable state; when clicked the corresponding series will disappear.</span>
+      <div class="ct-chart-line-clickable"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-clickable', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          clickable: false
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>legendNames</i>:</h3>
+      <span>Sets custom legend names. By default the <code>name</code> property of the series will be used if none are given.</span>
+      <div class="ct-chart-line-legendnames"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-legendnames', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       [12, 9, 7, 8, 5],
+       [2, 1, 3.5, 7, 3],
+       [1, 3, 4, 5, 6]
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          legendNames: ['Custom title', 'Another one', 'And the last one'],
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>onClick</i>:</h3>
+      <span>Accepts a function that gets invoked if <code>clickable</code> is true. The function has the <code>chart</code>, and the click event (<code>e</code>), as arguments.</span>
+      <div class="ct-chart-line-onclick"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-onclick', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          onClick: function () {
+             alert('Somebody clicked a legend!');
+          }
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>classNames</i>:</h3>
+      <span>Accepts a array of strings as long as the chart's series, those will be added as classes to the <code>li</code> elements.</span>
+      <div class="ct-chart-line-classnames"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-classnames', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          classNames: ['','ct-hidden','']
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>removeAll</i>:</h3>
+      <span>Allow all series to be removed at once.</span>
+      <div class="ct-chart-line-removeall"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-removeall', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          removeAll: true
+       })
+   ]
+});</code></pre>
+      <h3>Chart with <i>position</i>:</h3>
+      <span>Sets the position of the legend element. <code>top</code> and <code>bottom</code> are currently accepted.</span>
+      <div class="ct-chart-line-position"></div>
+      <button class="button-showcode">Show Code</button>
+<pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-position', {
+   labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+   series: [
+       { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+       { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+       { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+   ]
+}, {
+   fullWidth: true,
+   chartPadding: {
+      right: 40
+   },
+   plugins: [
+       Chartist.plugins.legend({
+          position: 'bottom'
+       })
+   ]
+});</code></pre>
+   </div>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/chartist/0.9.8/chartist.min.js"></script>
+   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+   <script>hljs.initHighlightingOnLoad();</script>
+   <script>
+      var deleteLink = document.querySelectorAll('.button-showcode');
+      for (var i = 0; i < deleteLink.length; i++)
+      {
+         deleteLink[i].addEventListener('click', function (event)
+         {
+            var el = this.nextSibling.nextSibling;
+            var className = 'codeblock-hidden';
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/chartist/0.9.8/chartist.min.js"></script>
-    <script src="chartist-plugin-legend.js"></script>
+            var classes = el.className.split(' ');
+            var existingIndex = classes.indexOf(className);
 
-    <script>
-        new Chartist.Line('.ct-chart-line', {
-            labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
-            series: [
-                [12, 9, 7, 8, 5],
-                [2, 1, 3.5, 7, 3],
-                [1, 3, 4, 5, 6]
-            ]
-        }, {
-            fullWidth: true,
-            chartPadding: {
-                right: 40
-            },
-            plugins: [
-                Chartist.plugins.legend({
-                    legendNames: ['Blue pill', 'Red pill', 'Purple pill'],
-                })
-            ]
-        });
+            if (existingIndex >= 0)
+            {
+               this.textContent = "Hide Code";
+               classes.splice(existingIndex, 1);
+            }
+            else
+            {
+               this.textContent = "Show Code";
+               classes.push(className);
+            }
 
-        new Chartist.Pie('.ct-chart-pie', {
-            labels: ['Piece A', 'Piece B', 'Piece C', 'Piece D'],
-            series: [20, 10, 30, 40]
-        }, {
-            showLabel: false,
-            plugins: [
-                Chartist.plugins.legend()
-            ]
-        });
+            el.className = classes.join(' ');
+         });
+      }
+   </script>
+   <script src="chartist-plugin-legend.js"></script>
 
-        new Chartist.Bar('.ct-chart-bar', {
-            labels: ['First quarter of the year', 'Second quarter of the year', 'Third quarter of the year', 'Fourth quarter of the year'],
-            series: [
-                {"name": "Money A", "data": [60000, 40000, 80000, 70000]},
-                {"name": "Money B", "data": [40000, 30000, 70000, 65000]},
-                {"name": "Money C", "data": [8000, 3000, 10000, 6000]}
-            ]
-        }, {
-            plugins: [
-                Chartist.plugins.legend()
-            ]
-        });
-    </script>
+   <script>
+      new Chartist.Line('.ct-chart-line', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             [12, 9, 7, 8, 5],
+             [2, 1, 3.5, 7, 3],
+             [1, 3, 4, 5, 6]
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                legendNames: ['Blue pill', 'Red pill', 'Purple pill'],
+             })
+         ]
+      });
+
+      new Chartist.Pie('.ct-chart-pie', {
+         labels: ['Piece A', 'Piece B', 'Piece C', 'Piece D'],
+         series: [20, 10, 30, 40]
+      }, {
+         showLabel: false,
+         plugins: [
+             Chartist.plugins.legend()
+         ]
+      });
+
+      new Chartist.Bar('.ct-chart-bar', {
+         labels: ['First quarter of the year', 'Second quarter of the year', 'Third quarter of the year', 'Fourth quarter of the year'],
+         series: [
+             { "name": "Money A", "data": [60000, 40000, 80000, 70000] },
+             { "name": "Money B", "data": [40000, 30000, 70000, 65000] },
+             { "name": "Money C", "data": [8000, 3000, 10000, 6000] }
+         ]
+      }, {
+         plugins: [
+             Chartist.plugins.legend()
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-classname', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                className: 'crazyPink'
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-clickable', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                clickable: false
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-legendnames', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             [12, 9, 7, 8, 5],
+             [2, 1, 3.5, 7, 3],
+             [1, 3, 4, 5, 6]
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                legendNames: ['Custom title', 'Another one', 'And the last one'],
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-onclick', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                onClick: function ()
+                {
+                   alert('Somebody clicked a legend!');
+                }
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-classnames', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                classNames: ['ct-dimmed', 'ct-hidden', '']
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-removeall', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                removeAll: true
+             })
+         ]
+      });
+
+      new Chartist.Line('.ct-chart-line-position', {
+         labels: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+         series: [
+             { "name": "Money A", "data": [12, 9, 7, 8, 5] },
+             { "name": "Money B", "data": [2, 1, 3.5, 7, 3] },
+             { "name": "Money C", "data": [1, 3, 4, 5, 6] }
+         ]
+      }, {
+         fullWidth: true,
+         chartPadding: {
+            right: 40
+         },
+         plugins: [
+             Chartist.plugins.legend({
+                position: 'bottom'
+             })
+         ]
+      });
+   </script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
    ]
 });</code></pre>
       <h3>Chart with <i>clickable</i>:</h3>
-      <span>Sets the legends clickable state; setting this value to <code>ul</code> disables toggling graphs on legend click.</span>
+      <span>Sets the legends clickable state; setting this value to <code>false</code> disables toggling graphs on legend click.</span>
       <div class="ct-chart-line-clickable"></div>
       <button class="button-showcode">Show Code</button>
 <pre class="codeblock-hidden"><code class="javascript">new Chartist.Line('.ct-chart-line-clickable', {

--- a/test/test.legend.js
+++ b/test/test.legend.js
@@ -113,8 +113,16 @@ describe('Chartist plugin legend', function() {
 
         it('should not insert legend twice', function () {
             window.Chartist.plugins.legend()(chart);
-            var matches = chart.container.querySelectorAll('ul.ct-legend');
-            expect(matches.length).to.equal(1);
+            // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+            chart.on('created', function ()
+            {
+               setTimeout(function ()
+               {
+                  var matches = chart.container.querySelectorAll('ul.ct-legend');
+                  expect(matches.length).to.equal(1);
+
+               }, 10)
+            });
         });
     });
 
@@ -180,45 +188,62 @@ describe('Chartist plugin legend', function() {
             var legendNames = ['Sheep', 'are', 'animals'];
             chart = generateChart('Line', chartDataLine, { legendNames: legendNames });
 
-            chart.on('created', function() {
-                var legendKey = 0;
-                var parent = chart.container.querySelector('ul.ct-legend');
+            // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+            chart.on('created', function () {
+               setTimeout(function () {
+                  var legendKey = 0;
+                  var parent = chart.container.querySelector('ul.ct-legend');
 
-                expect(parent.childNodes.length).to.equal(3);
-                [].forEach.call(parent.childNodes, function(item) {
-                    expect(item.innerHTML).to.equal(legendNames[legendKey]);
-                    legendKey += 1;
-                });
+                  expect(parent.childNodes.length).to.equal(3);
+                  [].forEach.call(parent.childNodes, function (item)
+                  {
+                     expect(item.innerHTML).to.equal(legendNames[legendKey]);
+                     legendKey += 1;
+                  });
 
-                destroyChart();
-                done();
+                  destroyChart();
+                  done();
+
+               }, 10)
             });
         });
 
         it('should allow a custom class name', function(done) {
             chart = generateChart('Line', chartDataLine, { className: 'bananas' });
 
-            chart.on('created', function() {
-                var legend = chart.container.querySelector('ul.ct-legend');
-                expect(legend.classList[1]).to.equal('bananas');
-                destroyChart();
-                done();
+            // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+            chart.on('created', function ()
+            {
+               setTimeout(function ()
+               {
+                  var legend = chart.container.querySelector('ul.ct-legend');
+                  expect(legend.classList[1]).to.equal('bananas');
+                  destroyChart();
+                  done();
+
+               }, 10)
             });
         });
-        
+
         it('should allow multiple custom class names', function (done) {
            var classNames = ['multiclass-0', 'multiclass-1', 'multiclass-hidden'];
            chart = generateChart('Line', chartDataLine, { classNames: classNames });
 
-           chart.on('created', function () {
-              var legend = chart.container.querySelector('ul.ct-legend');
+           // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+           chart.on('created', function ()
+           {
+              setTimeout(function ()
+              {
+                 var legend = chart.container.querySelector('ul.ct-legend');
 
-              expect(chart.data.series.length).to.equal(3);
-              expect(legend.children[0].classList.contains(classNames[0])).to.be.true;
-              expect(legend.children[1].classList.contains(classNames[1])).to.be.true;
-              expect(legend.children[2].classList.contains(classNames[2])).to.be.true;
-              destroyChart();
-              done();
+                 expect(chart.data.series.length).to.equal(3);
+                 expect(legend.children[0].classList.contains(classNames[0])).to.be.true;
+                 expect(legend.children[1].classList.contains(classNames[1])).to.be.true;
+                 expect(legend.children[2].classList.contains(classNames[2])).to.be.true;
+                 destroyChart();
+                 done();
+
+              }, 10)
            });
         });
 

--- a/test/test.legend.js
+++ b/test/test.legend.js
@@ -114,10 +114,8 @@ describe('Chartist plugin legend', function() {
         it('should not insert legend twice', function () {
             window.Chartist.plugins.legend()(chart);
             // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
-            chart.on('created', function ()
-            {
-               setTimeout(function ()
-               {
+            chart.on('created', function () {
+               setTimeout(function () {
                   var matches = chart.container.querySelectorAll('ul.ct-legend');
                   expect(matches.length).to.equal(1);
 
@@ -212,10 +210,8 @@ describe('Chartist plugin legend', function() {
             chart = generateChart('Line', chartDataLine, { className: 'bananas' });
 
             // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
-            chart.on('created', function ()
-            {
-               setTimeout(function ()
-               {
+            chart.on('created', function () {
+               setTimeout(function () {
                   var legend = chart.container.querySelector('ul.ct-legend');
                   expect(legend.classList[1]).to.equal('bananas');
                   destroyChart();
@@ -230,10 +226,8 @@ describe('Chartist plugin legend', function() {
            chart = generateChart('Line', chartDataLine, { classNames: classNames });
 
            // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
-           chart.on('created', function ()
-           {
-              setTimeout(function ()
-              {
+           chart.on('created', function () {
+              setTimeout(function () {
                  var legend = chart.container.querySelector('ul.ct-legend');
 
                  expect(chart.data.series.length).to.equal(3);
@@ -244,6 +238,36 @@ describe('Chartist plugin legend', function() {
                  done();
 
               }, 10)
+           });
+        });
+
+        describe('allow custom positioning', function () {
+           it('should allow top positioning', function (done) {
+              chart = generateChart('Line', chartDataLine, { position: 'top' });
+
+              // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+              chart.on('created', function () {
+                 setTimeout(function () {
+                    expect(chart.container.childNodes.length).to.equal(2);
+                    var listElement = chart.container.querySelector("ul");
+                    expect(chart.container.childNodes[0]).to.equal(listElement);
+                    done();
+                 }, 10)
+              });
+           });
+
+           it('should allow bottom positioning', function (done) {
+              chart = generateChart('Line', chartDataLine, { position: 'bottom' });
+
+              // Set a delay on the test to ensure it doesn't overlap with the plugin native 'created' handler
+              chart.on('created', function () {
+                 setTimeout(function () {
+                    expect(chart.container.childNodes.length).to.equal(2);
+                    var listElement = chart.container.querySelector("ul");
+                    expect(chart.container.childNodes[1]).to.equal(listElement);
+                    done();
+                 }, 10)
+              });
            });
         });
 


### PR DESCRIPTION
Adds option `position`, which is enumerated and accepts one of two positions currently: 'bottom' and 'top'. Now the legend element will (correctly) be added to the chart container on the `created` event, and pre- or appended to the `svg`.

I also reworked the demo page, added a small documentation to it, and rephrased option descriptions to be more precise.
